### PR TITLE
Add language priming support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ cargo build --release
 
 # Save audio while transcribing
 ./target/release/ears --live --save-audio recording.wav
+
+# Prime the model with reference audio in another language
+./target/release/ears --live -l ger
 ```
 
 ### File Transcription
@@ -63,6 +66,7 @@ cargo build --release
 - `--cpu` - Force CPU inference (disable GPU)
 - `--hf-repo <REPO>` - Specify Hugging Face model repository
 - `--list-devices` - List available audio devices
+- `-l, --lang <LANG>` - Prime language using audio snippet (esp, ger, jap)
 
 ## Model
 

--- a/ref_audio/README.md
+++ b/ref_audio/README.md
@@ -1,0 +1,2 @@
+This directory should contain short MP3 snippets used to prime the transcription model for other languages.
+Provide files named `esp.mp3`, `ger.mp3`, or `jap.mp3` with a few seconds of speech in Spanish, German or Japanese respectively.

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,10 @@ struct Args {
     /// Select audio input device by index. Use --list-devices to see available devices.
     #[arg(long)]
     device: Option<usize>,
+
+    /// Inject reference audio for language priming (esp, ger, jap)
+    #[arg(long, short = 'l', value_parser = ["esp", "ger", "jap"])]
+    lang: Option<String>,
 }
 
 fn main() -> Result<()> {
@@ -59,6 +63,13 @@ fn main() -> Result<()> {
         // Live microphone mode
         eprintln!("Loading model from repository: {}", args.hf_repo);
         let mut model = Model::load_from_hf(&args.hf_repo, args.cpu, options)?;
+
+        if let Some(ref lang) = args.lang {
+            let path = format!("ref_audio/{}.mp3", lang);
+            if let Err(e) = model.prime_with_audio(&path) {
+                eprintln!("Warning: failed to process reference audio {}: {}", path, e);
+            }
+        }
 
         let (audio_tx, audio_rx) = unbounded();
 


### PR DESCRIPTION
## Summary
- allow language priming with short reference audio snippets
- document new `--lang` CLI option
- include a `ref_audio` directory with instructions
- fix clap value parser for language option

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_b_6860e4701b64832184edcb006b9122ae