### PR TITLE
Add pause/resume command via WebSocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,13 +142,21 @@ Send from client to restart transcription after timeout or final message:
 }
 ```
 
+#### Pause/Resume Transcription
+Toggle live inference without disconnecting:
+```json
+{ "type": "pause" }
+{ "type": "resume" }
+```
+
 ### Usage Pattern
 
 1. Connect to WebSocket endpoint
 2. Receive real-time word messages during transcription
 3. Receive final message when session ends (timeout or silence)
 4. Send restart command to begin new transcription session
-5. Repeat as needed
+5. Optionally send pause/resume commands to temporarily stop inference
+6. Repeat as needed
 
 ## Model
 

--- a/websocket_example.html
+++ b/websocket_example.html
@@ -37,6 +37,7 @@
         <input type="text" id="wsUrl" value="ws://localhost:8080/" size="30">
         <button onclick="connect()">Connect</button>
         <button onclick="disconnect()">Disconnect</button>
+        <button id="pauseBtn" onclick="togglePause()" disabled>Pause</button>
     </div>
     
     <div>Status: <span id="status">Disconnected</span></div>
@@ -54,8 +55,10 @@
 
     <script>
         let ws = null;
+        let isPaused = false;
         const messagesDiv = document.getElementById('messages');
         const statusSpan = document.getElementById('status');
+        const pauseBtn = document.getElementById('pauseBtn');
 
         function connect() {
             const url = document.getElementById('wsUrl').value;
@@ -70,6 +73,9 @@
                 ws.onopen = function() {
                     statusSpan.textContent = 'Connected';
                     statusSpan.style.color = 'green';
+                    pauseBtn.disabled = false;
+                    pauseBtn.textContent = 'Pause';
+                    isPaused = false;
                     addMessage('Connected to eaRS WebSocket server', 'info');
                 };
                 
@@ -85,6 +91,9 @@
                 ws.onclose = function() {
                     statusSpan.textContent = 'Disconnected';
                     statusSpan.style.color = 'red';
+                    pauseBtn.disabled = true;
+                    pauseBtn.textContent = 'Pause';
+                    isPaused = false;
                     addMessage('Disconnected from server', 'info');
                     ws = null;
                 };
@@ -102,6 +111,22 @@
             if (ws) {
                 ws.close();
                 ws = null;
+            }
+            pauseBtn.disabled = true;
+            pauseBtn.textContent = 'Pause';
+            isPaused = false;
+        }
+
+        function togglePause() {
+            if (!ws) return;
+            if (isPaused) {
+                ws.send(JSON.stringify({ type: 'resume' }));
+                pauseBtn.textContent = 'Pause';
+                isPaused = false;
+            } else {
+                ws.send(JSON.stringify({ type: 'pause' }));
+                pauseBtn.textContent = 'Resume';
+                isPaused = true;
             }
         }
         


### PR DESCRIPTION
## Summary
- extend WebSocketCommand with `pause` and `resume`
- implement pause/resume handling in `transcribe_live_ws`
- add pause button and logic in `websocket_example.html`
- document pause/resume commands in README

## Testing
- `cargo fmt --all`
- `cargo check`
- `apt-get update && apt-get install -y libasound2-dev pkg-config`


------
https://chatgpt.com/codex/tasks/task_b_686a47c0a0f08321986c95e8e4af12c4