### PR TITLE
fix: resolve build failures for missing xi library and anyhow macro

### DIFF
--- a/justfile
+++ b/justfile
@@ -151,7 +151,8 @@ check-deps:
     
     # Detect OS
     if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-        # Linux: requires system sentencepiece to avoid protobuf conflicts
+        # Linux: requires system sentencepiece to avoid protobuf conflicts.
+        # Also requires X11 dev libraries for the rdev crate (input monitoring).
         if command -v apt-get &> /dev/null; then
             # Debian/Ubuntu
             if ! pkg-config --exists sentencepiece; then
@@ -161,6 +162,18 @@ check-deps:
             else
                 echo "✓ sentencepiece already installed"
             fi
+            if ! pkg-config --exists xi; then
+                echo "Installing libxi-dev (required by rdev)..."
+                sudo apt-get install -y libxi-dev
+            else
+                echo "✓ libxi-dev already installed"
+            fi
+            if ! pkg-config --exists xtst; then
+                echo "Installing libxtst-dev (required by rdev)..."
+                sudo apt-get install -y libxtst-dev
+            else
+                echo "✓ libxtst-dev already installed"
+            fi
         elif command -v dnf &> /dev/null; then
             # Fedora/RHEL
             if ! pkg-config --exists sentencepiece; then
@@ -168,6 +181,18 @@ check-deps:
                 sudo dnf install -y sentencepiece-devel
             else
                 echo "✓ sentencepiece already installed"
+            fi
+            if ! pkg-config --exists xi; then
+                echo "Installing libXi-devel (required by rdev)..."
+                sudo dnf install -y libXi-devel
+            else
+                echo "✓ libXi-devel already installed"
+            fi
+            if ! pkg-config --exists xtst; then
+                echo "Installing libXtst-devel (required by rdev)..."
+                sudo dnf install -y libXtst-devel
+            else
+                echo "✓ libXtst-devel already installed"
             fi
         elif command -v pacman &> /dev/null; then
             # Arch Linux
@@ -177,8 +202,23 @@ check-deps:
             else
                 echo "✓ sentencepiece already installed"
             fi
+            if ! pkg-config --exists xi; then
+                echo "Installing libxi (required by rdev)..."
+                sudo pacman -S --noconfirm libxi
+            else
+                echo "✓ libxi already installed"
+            fi
+            if ! pkg-config --exists xtst; then
+                echo "Installing libxtst (required by rdev)..."
+                sudo pacman -S --noconfirm libxtst
+            else
+                echo "✓ libxtst already installed"
+            fi
         else
-            echo "⚠ Unsupported Linux distribution. Please install sentencepiece manually."
+            echo "⚠ Unsupported Linux distribution. Please install manually:"
+            echo "  - sentencepiece dev library"
+            echo "  - libxi dev library   (xi.pc, required by rdev)"
+            echo "  - libxtst dev library (xtst.pc, required by rdev)"
             exit 1
         fi
     elif [[ "$OSTYPE" == "darwin"* ]]; then

--- a/src/virtual_keyboard.rs
+++ b/src/virtual_keyboard.rs
@@ -4,7 +4,7 @@
 //! - Linux (Wayland/X11): uinput kernel interface
 //! - Other platforms: enigo fallback
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, anyhow};
 
 #[cfg(target_os = "linux")]
 use uinput::{Device, event::keyboard};


### PR DESCRIPTION
## Summary

Two build errors prevented `just install-ears` from completing:

### Fix 1: `justfile` — missing `libxi` / `libxtst` dependency checks

The `check-deps` recipe only checked for `sentencepiece` on Linux. The `x11` crate requires `libxi >= 1.7` (xi.pc) at compile time, but `libxi-dev` (and `libxtst-dev`) were never installed by the recipe, causing the build to fail with:

```
The system library xi required by crate x11 was not found.
```

**Fix:** Added `pkg-config` presence checks and auto-install steps for `libxi` and `libxtst` across Debian/Ubuntu, Fedora/RHEL, and Arch Linux. Also improved the unsupported-distro error message to list all required libraries.

### Fix 2: `src/virtual_keyboard.rs` — missing `anyhow!` macro import

The `anyhow!` macro was used in `virtual_keyboard.rs` but only the `anyhow` crate itself was imported, not the macro, causing:

```
error: cannot find macro `anyhow` in this scope
```

**Fix:** Added `anyhow` to the existing import:
```rust
use anyhow::{Context, Result, anyhow};
```